### PR TITLE
Fix user avatar url type handling

### DIFF
--- a/auth/components/user-profile.tsx
+++ b/auth/components/user-profile.tsx
@@ -16,8 +16,12 @@ export function UserProfile() {
     return null
   }
 
-  // Type assertion to ensure profile has the correct type
-  const userProfile = profile as UserProfile
+  // Extract user profile fields with a type assertion to handle optional data
+  const {
+    avatar_url = '',
+    full_name,
+    role: profileRole,
+  } = profile as UserProfile
 
   const getInitials = (name: string) => {
     return name
@@ -37,9 +41,9 @@ export function UserProfile() {
   }
 
   // Safely get avatar URL with fallback
-  const avatarUrl = userProfile?.avatar_url || ''
-  const displayName = userProfile?.full_name || user.email || 'User'
-  const userRole = userProfile?.role || 'user'
+  const avatarUrl = avatar_url
+  const displayName = full_name || user.email || 'User'
+  const userRole = profileRole || 'user'
 
   return (
     <DropdownMenu>
@@ -48,7 +52,7 @@ export function UserProfile() {
           <Avatar className="h-8 w-8">
             <AvatarImage src={avatarUrl} alt={displayName} />
             <AvatarFallback>
-              {userProfile?.full_name ? getInitials(userProfile.full_name) : user.email?.[0]?.toUpperCase() || 'U'}
+              {full_name ? getInitials(full_name) : user.email?.[0]?.toUpperCase() || 'U'}
             </AvatarFallback>
           </Avatar>
         </Button>
@@ -102,7 +106,11 @@ export function UserProfileCompact() {
   }
 
   // Type assertion to ensure profile has the correct type
-  const userProfile = profile as UserProfile
+  const {
+    avatar_url: compactAvatarUrl = '',
+    full_name: compactFullName,
+    role: compactRole,
+  } = profile as UserProfile
 
   const getInitials = (name: string) => {
     return name
@@ -114,16 +122,16 @@ export function UserProfileCompact() {
   }
 
   // Safely get avatar URL with fallback
-  const avatarUrl = userProfile?.avatar_url || ''
-  const displayName = userProfile?.full_name || user.email || 'User'
-  const userRole = userProfile?.role || 'user'
+  const avatarUrl = compactAvatarUrl
+  const displayName = compactFullName || user.email || 'User'
+  const userRole = compactRole || 'user'
 
   return (
     <div className="flex items-center gap-2">
       <Avatar className="h-6 w-6">
         <AvatarImage src={avatarUrl} alt={displayName} />
         <AvatarFallback className="text-xs">
-          {userProfile?.full_name ? getInitials(userProfile.full_name) : user.email?.[0]?.toUpperCase() || 'U'}
+          {compactFullName ? getInitials(compactFullName) : user.email?.[0]?.toUpperCase() || 'U'}
         </AvatarFallback>
       </Avatar>
       <div className="hidden sm:block">


### PR DESCRIPTION
## Summary
- safely destructure user profile fields in `UserProfile` component
- use extracted fields to avoid TS errors when avatar URL is missing

## Testing
- `npx eslint auth/components/user-profile.tsx`
- `npx jest --runTestsByPath auth/components/user-profile.tsx` *(fails: E403 Forbidden)*
- `npx tsc --noEmit auth/components/user-profile.tsx` *(fails: missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_6887c21504608326aae280c3fd0a119c